### PR TITLE
improve test ergonomics

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Verify with Maven
-      run: mvn -B verify -Dtest.solr.allowed.securerandom=NativePRNG
+      run: mvn -B verify

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ You don't want to have producers dynamically creating kafka topics, because you 
 correct number of partitions (shards) by default when a topic is dynamically created.  It is best if
 there is just one entity in your cluster whose job is to sync the Solr's clusterstate with Kafka's
 topic + partition.  The natural place for this is the overseer. The
-[scheduled trigger](https://lucene.apache.org/solr/guide/7_3/solrcloud-autoscaling-triggers.html) c
-an run can run the sync check every N seconds.  N determines how quickly a topic is writable after
+[scheduled trigger](https://lucene.apache.org/solr/guide/7_3/solrcloud-autoscaling-triggers.html) can
+run can run the sync check every N seconds.  N determines how quickly a topic is writable after
 collection creation.
 
 ```
@@ -127,7 +127,7 @@ curl -s "localhost:8983/solr/admin/autoscaling" \
 
 **KafkaUpdateProcessorFactory Config**
 
-- Set `producer.linger.ms` to somthing greater than 0 ms (default) to send updates to kafka in batch.
+- Set `producer.linger.ms` to something greater than 0 ms (default) to send updates to kafka in batch.
   Note that this slows the /update HTTP response to wait for other requests.
 - Configure timeouts like `producer.request.timeout.ms` or `producer.max.block.ms` to define how
   Solr's update handler responds when it cannot send updates to kafka.  By default it responds in

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -73,6 +73,17 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.12.4</version>
+        <configuration>
+          <systemPropertyVariables>
+
+            <test.solr.allowed.securerandom>NativePRNG</test.solr.allowed.securerandom>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaAddUpdateCommandTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaAddUpdateCommandTest.java
@@ -25,7 +25,7 @@ public class KafkaAddUpdateCommandTest extends SingleCoreTestBase {
     ProducerRecord<String, byte[]> record = kafkaCmd.record("testTopic", 1);
     assertEquals(id, record.key());
     AddUpdateCommand deserialized =
-        new KafkaAddUpdateCommand(testCore, consumerize(record, 0)).getCommand();
+        new KafkaAddUpdateCommand(getTestCore(), consumerize(record, 0)).getCommand();
     assertEquals(123, deserialized.commitWithin);
     assertEquals(true, deserialized.overwrite);
     assertEquals(id, deserialized.getHashableId());

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaConsumerUpdateProcessorTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaConsumerUpdateProcessorTest.java
@@ -22,7 +22,7 @@ public class KafkaConsumerUpdateProcessorTest extends SingleCoreTestBase {
     long offset = 42;
     TestUpdateRequestProcessor.Factory f = new TestUpdateRequestProcessor.Factory();
     TestKafkaConsumerUpdateProcessor c =
-        new TestKafkaConsumerUpdateProcessor(testCore, "_offset_", f);
+        new TestKafkaConsumerUpdateProcessor(getTestCore(), "_offset_", f);
 
     /////////
     // ADD //
@@ -49,7 +49,7 @@ public class KafkaConsumerUpdateProcessorTest extends SingleCoreTestBase {
     directCmd.solrDoc = new SolrInputDocument();
     directCmd.solrDoc.setField("id", "real_doc_1");
     directCmd.solrDoc.setField("msg1_txt", "hi_1");
-    testCore.getUpdateHandler().addDoc(directCmd);
+    getTestCore().getUpdateHandler().addDoc(directCmd);
 
     AddUpdateCommand updateCmd = new AddUpdateCommand(emptyReq());
     updateCmd.solrDoc = new SolrInputDocument();
@@ -79,7 +79,7 @@ public class KafkaConsumerUpdateProcessorTest extends SingleCoreTestBase {
 
   @Test
   public void testRestOfChain() throws Exception {
-    KafkaConsumerUpdateProcessor c = new KafkaConsumerUpdateProcessor(testCore, "_offset_");
+    KafkaConsumerUpdateProcessor c = new KafkaConsumerUpdateProcessor(getTestCore(), "_offset_");
 
     // Test bad chains (kafka not in processors, in wrong order, etc)
     List<List<UpdateRequestProcessorFactory>> badChains = new ArrayList<>();
@@ -87,7 +87,7 @@ public class KafkaConsumerUpdateProcessorTest extends SingleCoreTestBase {
     badChains.add(Collections.singletonList(new DistributedUpdateProcessorFactory()));
     for (List<UpdateRequestProcessorFactory> chain : badChains) {
       try {
-        UpdateRequestProcessorChain noKafka = new UpdateRequestProcessorChain(chain, testCore);
+        UpdateRequestProcessorChain noKafka = new UpdateRequestProcessorChain(chain, getTestCore());
         c.restOfChain(noKafka);
         Assert.fail("invalid chain");
       } catch (Exception e) { // expected
@@ -101,7 +101,7 @@ public class KafkaConsumerUpdateProcessorTest extends SingleCoreTestBase {
     goodChain.add(new DistributedUpdateProcessorFactory());
     goodChain.add(r);
     UpdateRequestProcessorChain rest =
-        c.restOfChain(new UpdateRequestProcessorChain(goodChain, testCore));
+        c.restOfChain(new UpdateRequestProcessorChain(goodChain, getTestCore()));
     assertEquals(Collections.singletonList(r), rest.getProcessors());
   }
 }

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaDeleteUpdateCommandTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaDeleteUpdateCommandTest.java
@@ -20,7 +20,7 @@ public class KafkaDeleteUpdateCommandTest extends SingleCoreTestBase {
     ProducerRecord<String, byte[]> record = kafkaCmd.record("testTopic", 1);
     assertEquals(id, record.key());
     DeleteUpdateCommand deserialized =
-        new KafkaDeleteUpdateCommand(testCore, consumerize(record, 0)).getCommand();
+        new KafkaDeleteUpdateCommand(getTestCore(), consumerize(record, 0)).getCommand();
     assertEquals(123, deserialized.commitWithin);
     assertEquals(id, deserialized.id);
     assertNull(deserialized.query);
@@ -33,7 +33,7 @@ public class KafkaDeleteUpdateCommandTest extends SingleCoreTestBase {
     kafkaCmd = new KafkaDeleteUpdateCommand(cmd);
     record = kafkaCmd.record("testTopic", 1);
     assertEquals(query, record.key());
-    deserialized = new KafkaDeleteUpdateCommand(testCore, consumerize(record, 0)).getCommand();
+    deserialized = new KafkaDeleteUpdateCommand(getTestCore(), consumerize(record, 0)).getCommand();
     assertEquals(123, deserialized.commitWithin);
     assertEquals(query, deserialized.query);
     assertNull(deserialized.id);

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaTopicSyncActionTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaTopicSyncActionTest.java
@@ -24,13 +24,13 @@ public class KafkaTopicSyncActionTest extends SingleCoreTestBase {
     KafkaTopicSyncAction syncAction = new KafkaTopicSyncAction();
 
     try {
-      syncAction.configure(testCore.getResourceLoader(), null, Collections.emptyMap());
+      syncAction.configure(getTestCore().getResourceLoader(), null, Collections.emptyMap());
       Assert.fail("Expected configure exception without required params");
     } catch (TriggerValidationException tve) { // expected
     }
 
     syncAction.configure(
-        testCore.getResourceLoader(),
+        getTestCore().getResourceLoader(),
         null,
         Collections.singletonMap("bootstrap.servers", "localhost:9000"));
   }
@@ -45,7 +45,7 @@ public class KafkaTopicSyncActionTest extends SingleCoreTestBase {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put("bootstrap.servers", "localhost:9000");
     configMap.put("replication.factor", "11");
-    syncAction.configure(testCore.getResourceLoader(), null, configMap);
+    syncAction.configure(getTestCore().getResourceLoader(), null, configMap);
 
     TestSolrCloudManager cm = new TestSolrCloudManager();
     TestClusterStateProvider csp = new TestClusterStateProvider();

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaUpdateConsumerTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaUpdateConsumerTest.java
@@ -20,7 +20,14 @@ import org.apache.solr.update.CommitUpdateCommand;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class KafkaUpdateConsumerTest extends SingleCoreTestBase {
+/* This test suite needs a fresh core for each test,
+ * because it is manipulating the core state.
+ *
+ * Since SingleCoreTestBase (really, SolrTestCaseJ4)
+ * creates a core per test class, not per test,
+ * there are inner classes created for each case
+ */
+public class KafkaUpdateConsumerTest {
   static int testRetryPollMillis = 100;
 
   static class TestKafkaUpdateConsumer extends KafkaUpdateConsumer {
@@ -40,113 +47,130 @@ public class KafkaUpdateConsumerTest extends SingleCoreTestBase {
     }
   }
 
-  @Test
-  public void testRunShutdown() {
-    MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
-    KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
-    TestKafkaUpdateConsumer c =
-        new TestKafkaUpdateConsumer(testCore.getCoreContainer(), "localhost:9000", "_offset_");
-    c.reassign();
-    c.shutdown();
-    c.run();
-    // If we don't exit, shutdown didn't work
+  static class KafkaUpdateConsumerTestShutdown extends SingleCoreTestBase {
+    @Test
+    public void testRunShutdown() {
+      MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
+      KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
+      TestKafkaUpdateConsumer c =
+          new TestKafkaUpdateConsumer(
+              getTestCore().getCoreContainer(), "localhost:9000", "_offset_");
+      c.reassign();
+      c.shutdown();
+      c.run();
+      // If we don't exit, shutdown didn't work
+    }
   }
 
-  @Test
-  public void testConsumeAndReassign() throws Exception {
-    MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
-    TopicPartition tp = new TopicPartition("c1", 0);
-    kafkaConsumer.updateEndOffsets(Collections.singletonMap(tp, 0L));
-    KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
-    TestKafkaUpdateConsumer c =
-        new TestKafkaUpdateConsumer(testCore.getCoreContainer(), "localhost:9000", "_offset_");
+  static class KafkaUpdateConsumerTestConsumeAndReassign extends SingleCoreTestBase {
 
-    long start = System.currentTimeMillis();
-    // Confirm that if assignments are empty, we just return after a pause
-    c.consumeAndReassign();
-    boolean inRange = System.currentTimeMillis() - start >= testRetryPollMillis - 10;
-    assertTrue("when no assignment, waited before retry", inRange);
+    @Test
+    public void testConsumeAndReassign() throws Exception {
+      MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
+      TopicPartition tp = new TopicPartition("c1", 0);
+      kafkaConsumer.updateEndOffsets(Collections.singletonMap(tp, 0L));
+      KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
+      TestKafkaUpdateConsumer c =
+          new TestKafkaUpdateConsumer(
+              getTestCore().getCoreContainer(), "localhost:9000", "_offset_");
 
-    Properties cloudProps = new Properties();
-    cloudProps.put(CoreDescriptor.CORE_SHARD, "shard1");
-    cloudProps.put(CoreDescriptor.CORE_COLLECTION, "c1");
-    c.cloudDescMap =
-        Collections.singletonMap(
-            testCore,
-            new CloudDescriptor(testCore.getName(), cloudProps, testCore.getCoreDescriptor()));
-    c.consumeAndReassign();
+      long start = System.currentTimeMillis();
+      // Confirm that if assignments are empty, we just return after a pause
+      c.consumeAndReassign();
+      boolean inRange = System.currentTimeMillis() - start >= testRetryPollMillis - 10;
+      assertTrue("when no assignment, waited before retry", inRange);
 
-    // Confirm that this core, (c1, shard1) was assigned to TopicPartition (c1, 0)
-    KafkaConsumerUpdateProcessor p = c.partitionToProcessor.get(tp);
-    assertEquals(testCore, p.getCore());
+      Properties cloudProps = new Properties();
+      cloudProps.put(CoreDescriptor.CORE_SHARD, "shard1");
+      cloudProps.put(CoreDescriptor.CORE_COLLECTION, "c1");
+      c.cloudDescMap =
+          Collections.singletonMap(
+              getTestCore(),
+              new CloudDescriptor(
+                  getTestCore().getName(), cloudProps, getTestCore().getCoreDescriptor()));
+      c.consumeAndReassign();
 
-    TestUpdateRequestProcessor.Factory f = new TestUpdateRequestProcessor.Factory();
-    c.partitionToProcessor.put(tp, new TestKafkaConsumerUpdateProcessor(testCore, "_offset_", f));
+      // Confirm that this core, (c1, shard1) was assigned to TopicPartition (c1, 0)
+      KafkaConsumerUpdateProcessor p = c.partitionToProcessor.get(tp);
+      assertEquals(getTestCore(), p.getCore());
 
-    AddUpdateCommand cmd = new AddUpdateCommand(emptyReq());
-    cmd.solrDoc = new SolrInputDocument();
-    cmd.solrDoc.setField("id", "hi");
-    KafkaAddUpdateCommand kafkaCmd = new KafkaAddUpdateCommand(cmd);
-    ConsumerRecord<String, byte[]> cr = consumerize(kafkaCmd.record(tp.topic(), tp.partition()), 0);
-    kafkaConsumer.addRecord(cr);
+      TestUpdateRequestProcessor.Factory f = new TestUpdateRequestProcessor.Factory();
+      c.partitionToProcessor.put(
+          tp, new TestKafkaConsumerUpdateProcessor(getTestCore(), "_offset_", f));
 
-    c.consumeAndReassign();
-    assertEquals("hi", f.lastInstance.lastAdd.solrDoc.getFieldValue("id"));
+      AddUpdateCommand cmd = new AddUpdateCommand(emptyReq());
+      cmd.solrDoc = new SolrInputDocument();
+      cmd.solrDoc.setField("id", "hi");
+      KafkaAddUpdateCommand kafkaCmd = new KafkaAddUpdateCommand(cmd);
+      ConsumerRecord<String, byte[]> cr =
+          consumerize(kafkaCmd.record(tp.topic(), tp.partition()), 0);
+      kafkaConsumer.addRecord(cr);
+
+      c.consumeAndReassign();
+      assertEquals("hi", f.lastInstance.lastAdd.solrDoc.getFieldValue("id"));
+    }
   }
 
-  @Test
-  public void testConsumeAndReassignFromOffset() throws Exception {
-    MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
-    TopicPartition tp = new TopicPartition("c1", 0);
-    kafkaConsumer.updateEndOffsets(Collections.singletonMap(tp, 0L));
-    KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
-    TestKafkaUpdateConsumer c =
-        new TestKafkaUpdateConsumer(testCore.getCoreContainer(), "localhost:9000", "_offset_");
+  static class KafkaUpdateConsumerTestConsumeAndReassignFromOffset extends SingleCoreTestBase {
+    @Test
+    public void testConsumeAndReassignFromOffset() throws Exception {
+      MockConsumer<String, byte[]> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
+      TopicPartition tp = new TopicPartition("c1", 0);
+      kafkaConsumer.updateEndOffsets(Collections.singletonMap(tp, 0L));
+      KafkaClientFactory.INSTANCE = new TestKafkaClientFactory(kafkaConsumer);
+      TestKafkaUpdateConsumer c =
+          new TestKafkaUpdateConsumer(
+              getTestCore().getCoreContainer(), "localhost:9000", "_offset_");
 
-    Properties cloudProps = new Properties();
-    cloudProps.put(CoreDescriptor.CORE_SHARD, "shard1");
-    cloudProps.put(CoreDescriptor.CORE_COLLECTION, "c1");
-    c.cloudDescMap =
-        Collections.singletonMap(
-            testCore,
-            new CloudDescriptor(testCore.getName(), cloudProps, testCore.getCoreDescriptor()));
-    AddUpdateCommand directCmd = new AddUpdateCommand(emptyReq());
-    directCmd.solrDoc = new SolrInputDocument();
-    directCmd.solrDoc.setField("id", "real_doc_42");
-    directCmd.solrDoc.setField("_offset_", 42);
-    testCore.getUpdateHandler().addDoc(directCmd);
-    testCore.getUpdateHandler().commit(new CommitUpdateCommand(emptyReq(), false));
-
-    c.consumeAndReassign();
-    assertEquals(43, kafkaConsumer.position(tp));
-  }
-
-  @Test
-  public void testLoadOffset() throws Exception {
-    TestKafkaUpdateConsumer c =
-        new TestKafkaUpdateConsumer(testCore.getCoreContainer(), "localhost:9000", "_offset_");
-    // Should be null offset if no docs yet
-    Long offset = c.loadOffset(testCore);
-    Assert.assertNull(offset);
-
-    // add some docs to confirm offset calculation
-    for (long docOffset : new long[] {1L, 3L, 2L}) {
+      Properties cloudProps = new Properties();
+      cloudProps.put(CoreDescriptor.CORE_SHARD, "shard1");
+      cloudProps.put(CoreDescriptor.CORE_COLLECTION, "c1");
+      c.cloudDescMap =
+          Collections.singletonMap(
+              getTestCore(),
+              new CloudDescriptor(
+                  getTestCore().getName(), cloudProps, getTestCore().getCoreDescriptor()));
       AddUpdateCommand directCmd = new AddUpdateCommand(emptyReq());
       directCmd.solrDoc = new SolrInputDocument();
-      directCmd.solrDoc.setField("id", "real_doc_" + docOffset);
-      directCmd.solrDoc.setField("_offset_", docOffset);
-      testCore.getUpdateHandler().addDoc(directCmd);
-    }
-    testCore.getUpdateHandler().commit(new CommitUpdateCommand(emptyReq(), false));
-    offset = c.loadOffset(testCore);
-    assertEquals(Long.valueOf(3L), offset);
+      directCmd.solrDoc.setField("id", "real_doc_42");
+      directCmd.solrDoc.setField("_offset_", 42);
+      getTestCore().getUpdateHandler().addDoc(directCmd);
+      getTestCore().getUpdateHandler().commit(new CommitUpdateCommand(emptyReq(), false));
 
-    // expect an exception if the offset field can't be resolved in schema
-    try {
-      new TestKafkaUpdateConsumer(testCore.getCoreContainer(), "localhost:9000", "_foobar_")
-          .loadOffset(testCore);
-      Assert.fail("expected an exception if offset field can't be resolved");
-    } catch (Exception e) {
+      c.consumeAndReassign();
+      assertEquals(43, kafkaConsumer.position(tp));
+    }
+  }
+
+  static class KafkaUpdateConsumerTestLoadOffset extends SingleCoreTestBase {
+    @Test
+    public void testLoadOffset() throws Exception {
+      TestKafkaUpdateConsumer c =
+          new TestKafkaUpdateConsumer(
+              getTestCore().getCoreContainer(), "localhost:9000", "_offset_");
+      // Should be null offset if no docs yet
+      Long offset = c.loadOffset(getTestCore());
+      Assert.assertNull(offset);
+
+      // add some docs to confirm offset calculation
+      for (long docOffset : new long[] {1L, 3L, 2L}) {
+        AddUpdateCommand directCmd = new AddUpdateCommand(emptyReq());
+        directCmd.solrDoc = new SolrInputDocument();
+        directCmd.solrDoc.setField("id", "real_doc_" + docOffset);
+        directCmd.solrDoc.setField("_offset_", docOffset);
+        getTestCore().getUpdateHandler().addDoc(directCmd);
+      }
+      getTestCore().getUpdateHandler().commit(new CommitUpdateCommand(emptyReq(), false));
+      offset = c.loadOffset(getTestCore());
+      assertEquals(Long.valueOf(3L), offset);
+
+      // expect an exception if the offset field can't be resolved in schema
+      try {
+        new TestKafkaUpdateConsumer(getTestCore().getCoreContainer(), "localhost:9000", "_foobar_")
+            .loadOffset(getTestCore());
+        Assert.fail("expected an exception if offset field can't be resolved");
+      } catch (Exception e) {
+      }
     }
   }
 }

--- a/src/test/java/com/github/solrqueue/solrkafka/KafkaUpdateProcessorFactoryTest.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/KafkaUpdateProcessorFactoryTest.java
@@ -6,7 +6,7 @@ import org.apache.solr.common.util.NamedList;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class KafkaUpdateProcessorFactoryTest extends SingleCoreTestBase {
+public class KafkaUpdateProcessorFactoryTest {
   @Test
   public void testInit() throws Exception {
     KafkaUpdateProcessorFactory factory = new KafkaUpdateProcessorFactory();

--- a/src/test/java/com/github/solrqueue/solrkafka/SingleCoreTestBase.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/SingleCoreTestBase.java
@@ -1,28 +1,18 @@
 package com.github.solrqueue.solrkafka;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Random;
-import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.solr.core.CoreContainer;
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.request.LocalSolrQueryRequest;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
 
-public class SingleCoreTestBase {
-  protected SolrCore testCore;
+public class SingleCoreTestBase extends SolrTestCaseJ4 {
 
   protected LocalSolrQueryRequest emptyReq() {
-    return new LocalSolrQueryRequest(testCore, Collections.emptyMap());
+    return new LocalSolrQueryRequest(getTestCore(), Collections.emptyMap());
   }
 
   protected <K, V> ConsumerRecord<K, V> consumerize(ProducerRecord<K, V> r, long offset) {
@@ -40,36 +30,12 @@ public class SingleCoreTestBase {
         r.headers());
   }
 
-  @Before
-  public void setUp() throws Exception {
-    File solrHome = new File("src/test/resources/solr_home");
-    Path tempDir = Files.createTempDirectory("solrTest");
-    FileUtils.copyDirectory(solrHome, tempDir.toFile());
-    String newCoreName = "testcore_" + new Random().nextInt();
-    FileUtils.moveDirectory(
-        tempDir.resolve("testcore").toFile(), tempDir.resolve(newCoreName).toFile());
-    SolrResourceLoader loader = new SolrResourceLoader(tempDir);
-    CoreContainer container = new CoreContainer(loader);
-    container.load();
-    container.create(newCoreName, Collections.emptyMap());
-    new EmbeddedSolrServer(container, newCoreName);
-    testCore = container.getCore(newCoreName);
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  try {
-                    FileUtils.deleteDirectory(tempDir.toFile());
-                  } catch (IOException ioe) {
-                  }
-                }));
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    initCore("solrconfig.xml", "managed-schema", "src/test/resources/solr_home", "testcore");
   }
 
-  @After
-  public void tearDown() throws Exception {
-    // Manually cleanup the testcore data directory
-    if (testCore != null) {
-      testCore.closeSearcher();
-    }
+  public SolrCore getTestCore() {
+    return h.getCore();
   }
 }

--- a/src/test/java/com/github/solrqueue/solrkafka/integration/TestSolrKafkaDistrib.java
+++ b/src/test/java/com/github/solrqueue/solrkafka/integration/TestSolrKafkaDistrib.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
-import org.apache.solr.SolrTestCaseJ4.SuppressObjectReleaseTracker;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrRequest.METHOD;
@@ -49,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
 
-@SuppressObjectReleaseTracker(bugUrl = "leaks no objects in single test")
 @LogLevel("com.github.solrqueue.solrkafka=DEBUG")
 public class TestSolrKafkaDistrib extends SolrCloudTestCase {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION
add -Dtest.solr.allowed.securerandom=NativePRNG to surefire default
remove, with great effort, SuppressObjectReleaseTracker

I had to convert SingleCoreTestBase to use SolrTestCaseJ4,
because the leak tracking across tests works cooperatively