### PR TITLE
bump to kafka 2.2.1

### DIFF
--- a/.maintainers_guide.md
+++ b/.maintainers_guide.md
@@ -10,6 +10,38 @@ this project. If you use this package within your own software as is but don't p
 
 Run the test and code-coverage suite with the `mvn verify` command.
 
+Run the live demo:
+
+```
+make release-verify
+```
+
+You should see basic output like at the end:
+
+```
+{
+  "responseHeader":{
+    "zkConnected":true,
+    "status":0,
+    "QTime":245,
+    "params":{
+      "q":"*:*"}},
+  "response":{"numFound":3,"start":0,"maxScore":1.0,"docs":[
+      {
+        "id":"2",
+        "msg_s":"msg2",
+        "_offset_":0},
+      {
+        "id":"3",
+        "msg_s":"msg3",
+        "_offset_":1},
+      {
+        "id":"1",
+        "msg_s":"msg1",
+        "_offset_":0}]
+  }}
+```
+
 ### Releasing
 
 To push a new release, follow these steps:

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,8 @@ DEP_JARS=`mvn -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath" | tr 
 
 DEPS="
 kafka-clients-${KAFKA_VER}.jar
-lz4-java-1.4.1.jar
-snappy-java-1.1.7.1.jar
+lz4-java-1.5.0.jar
+snappy-java-1.1.7.2.jar
 "
 
 for dep in $DEPS; do

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <properties>
     <solr.version>7.5.0</solr.version>
+    <kafka.version>2.2.1</kafka.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -40,7 +41,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.0.0</version>
+      <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>
@@ -67,7 +68,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
-      <version>2.0.0</version>
+      <version>${kafka.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1,11 +1,13 @@
 package org.apache.kafka.clients.admin;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionReplica;
 import org.apache.kafka.common.acl.AclBinding;
@@ -20,7 +22,7 @@ public class MockAdminClient extends AdminClient {
   public int deletedTopics = 0;
 
   @Override
-  public void close(long l, TimeUnit timeUnit) {}
+  public void close(Duration duration) {}
 
   @Override
   public CreateTopicsResult createTopics(
@@ -171,6 +173,18 @@ public class MockAdminClient extends AdminClient {
   @Override
   public DeleteConsumerGroupsResult deleteConsumerGroups(
       Collection<String> collection, DeleteConsumerGroupsOptions deleteConsumerGroupsOptions) {
+    return null;
+  }
+
+  @Override
+  public ElectPreferredLeadersResult electPreferredLeaders(
+      Collection<TopicPartition> collection,
+      ElectPreferredLeadersOptions electPreferredLeadersOptions) {
+    return null;
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
     return null;
   }
 }


### PR DESCRIPTION
may help with admin client zombie thread in tests

adds a new `make release-verify` command that verifies
key parts of the build: the unit and integration junit tests,
the live demo, and the makefile demo system itself